### PR TITLE
Improving commands output

### DIFF
--- a/onmydesk/management/commands/process.py
+++ b/onmydesk/management/commands/process.py
@@ -24,6 +24,8 @@ class Command(BaseCommand):
         """Entrypoint of our command."""
         try:
             self._process_with_lock(options.get('ids'))
+        except filelock.Timeout:
+            self.stdout.write('Could not obtain lock to process reports')
         except Exception as e:
             traceback.print_exc()
             self.stdout.write('Error: {}'.format(str(e)))

--- a/onmydesk/management/commands/process.py
+++ b/onmydesk/management/commands/process.py
@@ -8,6 +8,7 @@ from django.core.management.base import BaseCommand
 import filelock
 import traceback
 from onmydesk.models import Report
+from onmydesk.utils import log_prefix
 
 
 class Command(BaseCommand):
@@ -46,18 +47,18 @@ class Command(BaseCommand):
 
         count = len(items)
 
-        self.stdout.write('Found {} reports to process'.format(count))
+        self.stdout.write(log_prefix() + 'Found {} reports to process'.format(count))
         for i, report in enumerate(items, start=1):
-            self.stdout.write('Processing report #{} - {} of {}'.format(
+            self.stdout.write(log_prefix() + 'Processing report #{} - {} of {}'.format(
                 report.id, i, count))
 
             try:
                 report.process()
                 report.save()
-                self.stdout.write('Report #{} processed'.format(report.id))
+                self.stdout.write(log_prefix() + 'Report #{} processed'.format(report.id))
             except Exception as e:
                 traceback.print_exc()
-                self.stderr.write('Error processing report #{}: {}'.format(
+                self.stderr.write(log_prefix() + 'Error processing report #{}: {}'.format(
                     report.id, str(e)))
 
     def _get_lock_filepath(self):

--- a/onmydesk/management/commands/scheduler_process.py
+++ b/onmydesk/management/commands/scheduler_process.py
@@ -19,6 +19,8 @@ class Command(BaseCommand):
         """Entrypoint of our command."""
         try:
             self._process_with_lock()
+        except filelock.Timeout:
+            self.stdout.write('Could not obtain lock to process scheduler')
         except Exception as e:
             self.stdout.write('Error: {}'.format(e))
 

--- a/onmydesk/management/commands/scheduler_process.py
+++ b/onmydesk/management/commands/scheduler_process.py
@@ -8,6 +8,7 @@ from django.core.management.base import BaseCommand
 
 import filelock
 from onmydesk.models import Scheduler
+from onmydesk.utils import log_prefix
 
 
 class Command(BaseCommand):
@@ -34,7 +35,7 @@ class Command(BaseCommand):
         return path.join(tempfile.gettempdir(), 'onmydesk-scheduler-processor-lock')
 
     def _process_schedulers(self):
-        self.stdout.write('Starting scheduler process')
+        self.stdout.write(log_prefix() + 'Starting scheduler process')
 
         today = date.today()
 
@@ -44,7 +45,7 @@ class Command(BaseCommand):
 
         count = len(items)
 
-        self.stdout.write('Found {} schedulers to process'.format(count))
+        self.stdout.write(log_prefix() + 'Found {} schedulers to process'.format(count))
 
         for i, scheduler in enumerate(items, start=1):
             self.stdout.write('Processing scheduler #{} - {} of {}'.format(
@@ -52,7 +53,7 @@ class Command(BaseCommand):
 
             try:
                 scheduler.process(reference_date=today)
-                self.stdout.write('Scheduler #{} processed'.format(scheduler.id))
+                self.stdout.write(log_prefix() + 'Scheduler #{} processed'.format(scheduler.id))
             except Exception as e:
-                self.stderr.write('Error processing scheduler #{}: {}'.format(
+                self.stderr.write(log_prefix() + 'Error processing scheduler #{}: {}'.format(
                     scheduler.id, str(e)))

--- a/onmydesk/tests/test_commands.py
+++ b/onmydesk/tests/test_commands.py
@@ -80,8 +80,8 @@ class SchedulerProcesssTestCase(TestCase):
         first_message = 'Starting scheduler process'
         last_message = 'Scheduler #{} processed'.format(scheduler.id)
 
-        self.assertEqual(first_line, first_message)
-        self.assertEqual(last_line, last_message)
+        self.assertIn(first_message, first_line)
+        self.assertIn(last_message, last_line)
         self.assertEqual(blank_line, '')
 
     def test_call_must_create_correct_report(self):

--- a/onmydesk/utils.py
+++ b/onmydesk/utils.py
@@ -1,7 +1,7 @@
 """Module with common utilities to this package."""
 
 import re
-from datetime import timedelta
+from datetime import datetime, timedelta
 import importlib
 
 
@@ -30,6 +30,10 @@ def my_import(class_name):
         msg = 'Could not import "{}" from {}: {}.'.format(
             class_name, e.__class__.__name__, e)
         raise ImportError(msg)
+
+
+def log_prefix():
+    return '{}: '.format(datetime.now().isoformat(' '))
 
 
 def str_to_date(value, reference_date):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py34,py27}-django{16,17,18,19}
+envlist = {py34,py27}-django{17,18,19}
 
 [testenv]
 deps=pytest
@@ -11,9 +11,8 @@ deps=pytest
      # To be used by coverage report
      pytest-cov
      # Testing with different django versions
-     django16: django>=1.6,<1.7
      django17: django>=1.7,<1.8
      django18: django>=1.8,<1.9
-     django19: django>=1.9,<2.0
+     django19: django>=1.9,<1.10
 
 commands=py.test --cov=onmydesk --cov-report= --cov-append


### PR DESCRIPTION
Make commands output datetime so that the log doesn't look like:

    Found 0 reports to process
    Found 0 reports to process
    Found 0 reports to process
    Found 0 reports to process
    ...

Also, fixes test configurations.